### PR TITLE
Set go version to 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9
+- 1.8
 
 before_deploy:
 - git config --local user.name "dfredell"


### PR DESCRIPTION
Set go version to 1.8, as that is what works locally, go 1.9 in Travis results in a runtime ERROR: collector failed after 0.058120s: Failed to parse server response.  source="minio_exporter.go:118"